### PR TITLE
clarify different available version categories

### DIFF
--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -322,7 +322,7 @@ const VersionSelector = ({
       <Selectors>
         <FromVersionSelector
           data-testid={testIDs.fromVersionSelector}
-          title={`What's your current ${packageName} version?`}
+          title={`What's your current Backstage release or @backstage/create-app (0.4.x) version?`}
           loading={isLoading}
           value={localFromVersion}
           options={fromVersionList}


### PR DESCRIPTION
Switches the messaging to this:

![image](https://user-images.githubusercontent.com/4984472/152838965-ebbe8497-3d9c-4212-b430-026cf33b591f.png)

Other suggestions are welcome :grin:
