### PR TITLE
Add link reference to a raw git diff

### DIFF
--- a/src/components/common/DiffViewer.js
+++ b/src/components/common/DiffViewer.js
@@ -11,6 +11,7 @@ import UsefulContentSection from './UsefulContentSection'
 import BinaryDownload from './BinaryDownload'
 import ViewStyleOptions from './Diff/DiffViewStyleOptions'
 import CompletedFilesCounter from './CompletedFilesCounter'
+import RawDiffLinkButton from './RawDiffLinkButton'
 import { useFetchDiff } from '../../hooks/fetch-diff'
 
 const Container = styled.div`
@@ -164,6 +165,13 @@ const DiffViewer = ({
               toVersion={toVersion}
               appName={appName}
               packageName={packageName}
+            />
+
+            <RawDiffLinkButton
+              packageName={packageName}
+              language={language}
+              fromVersion={fromVersion}
+              toVersion={toVersion}
             />
 
             <ViewStyleOptions

--- a/src/components/common/RawDiffLinkButton.js
+++ b/src/components/common/RawDiffLinkButton.js
@@ -6,13 +6,15 @@ import { getDiffURL } from '../../utils'
 const Container = styled.div`
   display: flex;
   justify-content: center;
-  height: auto;
-  overflow: hidden;
-  margin-top: 25px;
+  top: 10px;
+  font-size: 12px;
+  border-width: 0px;
+  height: 20px;
 `
 
 const Button = styled(AntdButton)`
   border-radius: 3px;
+  line-height: 30px;
 `
 
 const RawDiffLinkButton = ({
@@ -32,8 +34,8 @@ const RawDiffLinkButton = ({
   })
   return (
     <Container>
-      <Button href={diffURL} type="link" size="large">
-        See raw text diff
+      <Button href={diffURL} type="link">
+        View raw diff
       </Button>
     </Container>
   )

--- a/src/components/common/RawDiffLinkButton.js
+++ b/src/components/common/RawDiffLinkButton.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import { Button as AntdButton } from 'antd'
+import { getDiffURL } from '../../utils'
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  height: auto;
+  overflow: hidden;
+  margin-top: 25px;
+`
+
+const Button = styled(AntdButton)`
+  border-radius: 3px;
+`
+
+const RawDiffLinkButton = ({
+  packageName,
+  language,
+  fromVersion,
+  toVersion
+}) => {
+  if (fromVersion === '') {
+    return null
+  }
+  const diffURL = getDiffURL({
+    packageName,
+    language,
+    fromVersion,
+    toVersion
+  })
+  return (
+    <Container>
+      <Button href={diffURL} type="link" size="large">
+        See raw text diff
+      </Button>
+    </Container>
+  )
+}
+
+export default RawDiffLinkButton

--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -9,7 +9,6 @@ import UpgradeButton from './UpgradeButton'
 import { updateURL } from '../../utils/update-url'
 import { deviceSizes } from '../../utils/device-sizes'
 import { useReleases } from '../../ReleaseProvider'
-import RawDiffLinkButton from './RawDiffLinkButton'
 
 export const testIDs = {
   fromVersionSelector: 'fromVersionSelector',
@@ -173,8 +172,6 @@ const VersionSelector = ({
   packageName,
   language,
   isPackageNameDefinedInURL,
-  fromVersion,
-  toVersion,
   showDiff,
   showReleaseCandidates
 }) => {
@@ -365,12 +362,6 @@ const VersionSelector = ({
       </Selectors>
 
       <UpgradeButton ref={upgradeButtonEl} onShowDiff={onShowDiff} />
-      <RawDiffLinkButton
-        packageName={packageName}
-        language={language}
-        fromVersion={fromVersion}
-        toVersion={toVersion}
-      />
     </Fragment>
   )
 }

--- a/src/components/common/VersionSelector.js
+++ b/src/components/common/VersionSelector.js
@@ -9,6 +9,7 @@ import UpgradeButton from './UpgradeButton'
 import { updateURL } from '../../utils/update-url'
 import { deviceSizes } from '../../utils/device-sizes'
 import { useReleases } from '../../ReleaseProvider'
+import RawDiffLinkButton from './RawDiffLinkButton'
 
 export const testIDs = {
   fromVersionSelector: 'fromVersionSelector',
@@ -172,6 +173,8 @@ const VersionSelector = ({
   packageName,
   language,
   isPackageNameDefinedInURL,
+  fromVersion,
+  toVersion,
   showDiff,
   showReleaseCandidates
 }) => {
@@ -362,6 +365,12 @@ const VersionSelector = ({
       </Selectors>
 
       <UpgradeButton ref={upgradeButtonEl} onShowDiff={onShowDiff} />
+      <RawDiffLinkButton
+        packageName={packageName}
+        language={language}
+        fromVersion={fromVersion}
+        toVersion={toVersion}
+      />
     </Fragment>
   )
 }

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -191,6 +191,8 @@ const Home = () => {
             key={packageName}
             showDiff={handleShowDiff}
             showReleaseCandidates={settings[SHOW_LATEST_RCS]}
+            fromVersion={fromVersion}
+            toVersion={toVersion}
             packageName={packageName}
             language={language}
             isPackageNameDefinedInURL={isPackageNameDefinedInURL}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
* What issues does the pull request solve?
As per this issue https://github.com/backstage/backstage/issues/11642 it would be nice to have access to a git diff that people can then simply apply with `git apply patch.diff`.

* What is the feature? (if applicable)
This PR adds a link onto the main page that links to a raw diff generated by https://github.com/backstage/upgrade-helper-diff .

* How did you implement the solution?
I implemented it as "copy" of `UpgradeButton` component, and just adjusted it / passed in version variables, plus I used the `getDiffURL` function to get the relevant raw diff URL.

* What areas of the website does it impact?
It Impacts the home page.

## Test Plan

I am not sure how to easily create a gif of the change. Here is a picture before you click on the "Show me how to upgrade"
![image](https://user-images.githubusercontent.com/28529900/172637235-55f12ea6-72fc-4e08-b26e-4f6e1df45f8a.png)

Image after you click on the "Show me how to upgrade"
![image](https://user-images.githubusercontent.com/28529900/172637425-b6f93c79-5d6e-428d-96be-722a1e4b5945.png)

The "See raw text diff" link redirects you to a relevant diff

## What are the steps to reproduce?
Clone my fork
```
yarn start
```
Then select some diffs, and click on the "Show me how to upgrade"

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I tested this thoroughly... or at least I was not able to find a way how to break it
- [ ] I added the documentation in `README.md` (if needed) ... I still have to add some documentation to the backstage repo docs so that people know why it is there, and how they can use it.

