### PR TITLE
Stop some redundant pre-release versions from showing

### DIFF
--- a/src/components/common/UsefulContentSection.js
+++ b/src/components/common/UsefulContentSection.js
@@ -85,6 +85,36 @@ const ContentContainer = styled(({ isContentVisible, children, ...props }) => (
   }
 `
 
+// Filter all versions for versions that represent pre-release versions with "next" keyword,
+// but keep versions that don't have a full version yet.
+const removeRedundantPreReleases = versions => {
+  let fullVersions = []
+  let filteredVersions = []
+
+  versions.forEach(versionObject => {
+    if (!versionObject.version.includes('next')) {
+      fullVersions.push(versionObject)
+    }
+  })
+
+  // Find versions that do cannot be represented using full versions
+  versions.forEach(versionObject => {
+    let hasFullVersion = false
+    fullVersions.forEach(fullVersion => {
+      if (versionObject.version.includes(fullVersion.version)) {
+        hasFullVersion = true
+      }
+    })
+
+    // Cases where we did not find a full version representation can be assumed
+    // that they are actual pre-release versions
+    if (!hasFullVersion) {
+      filteredVersions.push(versionObject)
+    }
+  })
+  return filteredVersions.concat(fullVersions)
+}
+
 const Icon = styled(props => (
   <span {...props} role="img" aria-label="Megaphone emoji">
     📣
@@ -195,11 +225,12 @@ class UsefulContentSection extends Component {
   render() {
     const { isContentVisible } = this.state
 
-    const versions = getVersionsContentInDiff({
+    const allVersions = getVersionsContentInDiff({
       fromVersion: this.context.from.version,
       toVersion: this.context.to.version,
       versions: this.context.releases
     })
+    const versions = removeRedundantPreReleases(allVersions)
 
     const hasMoreThanOneRelease = versions.length > 1
 


### PR DESCRIPTION

# Summary
As per this issue https://github.com/backstage/backstage/issues/13446 . The "helpful content for upgrading" part contained pre-release versions that were somewhat redundant. So I added a filter that removed the redundant ones based on the `next` keyword
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the website does it impact?
-->

## Test Plan
I tried with older versions against full releases with no problems
![image](https://user-images.githubusercontent.com/28529900/188685789-9d7ca28a-25b8-419f-ad5e-7267b8a574b0.png)

and comparison between pre-releases
![image](https://user-images.githubusercontent.com/28529900/188686107-bb70944f-99b7-42f8-9487-ee51ffdc97aa.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
