### PR TITLE
Added temp filter to remove next versions from dropdowns

### DIFF
--- a/src/hooks/fetch-release-versions.js
+++ b/src/hooks/fetch-release-versions.js
@@ -17,7 +17,9 @@ export const useFetchReleases = ({ packageName }) => {
 
       const _releases = Object.entries(response)
         .map(([version, value]) => ({ version, ...value }))
+        .filter(({ version }) => version.includes('-next') === false) // TODO(hhogg): remove this temp filter
         .sort((a, b) => compare(a.version, b.version))
+
       setReleases(_releases)
 
       setIsLoading(false)


### PR DESCRIPTION
Simple filter of next versions from the upgrade helper so we can start developing support for them. 