### PR TITLE
Filter out yarn.lock files when displaying diffs

### DIFF
--- a/src/hooks/fetch-diff.js
+++ b/src/hooks/fetch-diff.js
@@ -5,8 +5,11 @@ import { useSettings } from '../SettingsProvider'
 
 const delay = ms => new Promise(res => setTimeout(res, ms))
 
-const movePackageJsonToTop = parsedDiff =>
-  parsedDiff.sort(({ newPath }) => (newPath.includes('package.json') ? -1 : 1))
+const excludeYarnLock = ({ oldPath, newPath, ...rest }) =>
+  !(oldPath.includes('yarn.lock') || newPath.includes('yarn.lock'))
+
+const packageJsonFirst = ({ newPath }) =>
+  newPath.includes('package.json') ? -1 : 1
 
 export const useFetchDiff = ({
   shouldShowDiff,
@@ -42,7 +45,11 @@ export const useFetchDiff = ({
 
       const diff = await response.text()
 
-      setDiff(movePackageJsonToTop(parseDiff(diff)))
+      setDiff(
+        parseDiff(diff)
+          .filter(excludeYarnLock)
+          .sort(packageJsonFirst)
+      )
 
       setIsLoading(false)
       setIsDone(true)


### PR DESCRIPTION
# Summary

We have a few spurious historic diffs in yarn.lock due to the changes in the way lockfile seeding works in create-app. These diffs are never relevant for upgraders - they're not expected to update their yarn.lock file in response to seed changes. With that in mind, it makes sense to always filter out any changes in yarn.lock in the diff.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## What are the steps to reproduce?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
