### PR TITLE
fix: correctly replace app name in file path

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -116,16 +116,13 @@ const UpdateDocsLink = styled.div`
   flex: 1;
 `
 
-const getAppInfoInURL = (): {
-  appPackage: string
-  appName: string
-} => {
+const getAppInfoInURL = () => {
   // Parses `/?name=RnDiffApp&package=com.rndiffapp` from URL
   const { name, package: pkg } = queryString.parse(window.location.search)
 
   return {
     appPackage: pkg as string,
-    appName: name as string,
+    appName: name as string | null,
   }
 }
 
@@ -161,13 +158,13 @@ const Home = () => {
   // })
 
   const appInfoInURL = getAppInfoInURL()
-  const [appName /* setAppName */] = useState('')
+  const [appName /* setAppName */] = useState(appInfoInURL.appName)
   const [appPackage /*setAppPackage*/] = useState<string>(
     appInfoInURL.appPackage
   )
 
   // Avoid UI lag when typing.
-  const deferredAppName = useDeferredValue(appName)
+  const deferredAppName = useDeferredValue(appName || DEFAULT_APP_NAME)
   const deferredAppPackage = useDeferredValue(appPackage)
 
   // const homepageUrl = process.env.PUBLIC_URL
@@ -305,9 +302,7 @@ const Home = () => {
                 shouldShowDiff={shouldShowDiff}
                 fromVersion={fromVersion}
                 toVersion={toVersion}
-                appName={
-                  deferredAppName !== DEFAULT_APP_NAME ? deferredAppName : ''
-                }
+                appName={deferredAppName}
                 appPackage={
                   deferredAppPackage !== DEFAULT_APP_PACKAGE
                     ? deferredAppPackage


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->



# Summary

Fixed an issue causing a missing `/` in the file path.

![415184399-178eefdb-7669-4fe4-b108-8ce37b0611d7](https://github.com/user-attachments/assets/ea6c133b-ad5a-4cac-b1a6-872c6afd1514)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I tested this thoroughly
- [ ] I added the documentation in `README.md` (if needed)
