### PR TITLE
Fix Home page URL from `react-native-community` to `backstage`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "upgrade-helper",
   "version": "0.1.0",
   "license": "MIT",
-  "homepage": "https://react-native-community.github.io/upgrade-helper",
+  "homepage": "https://backstage.github.io/upgrade-helper",
   "scripts": {
     "build": "EXTEND_ESLINT=true react-app-rewired build",
     "docker-test-e2e": "yarn start-and-wait && react-app-rewired test --watchAll=false --onlyChanged=false --testPathPattern='/__tests__/.*(\\.|).e2e.spec.(js|jsx|ts|tsx)?$'",


### PR DESCRIPTION
Fix Home page URL from `react-native-community` to `backstage`, otherwise clicking on the "Backstage Upgrade Helper" title is landing to https://react-native-community.github.io/upgrade-helper/ instead of https://backstage.github.io/upgrade-helper.

<img width="502" height="440" alt="image" src="https://github.com/user-attachments/assets/09b4e3d5-c31c-453b-a33e-f7e39614dd50" />

