### PR TITLE
Fetch diffs from the new branches

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,8 +10,18 @@ import { ReleaseT } from './releases/types'
 
 const getRNDiffRepository = ({ packageName }: { packageName: string }) =>
   RN_DIFF_REPOSITORIES[packageName]
-const getDiffBranch = ({ packageName }: { packageName: string }) =>
-  packageName === PACKAGE_NAMES.BACKSTAGE ? 'master' : 'diffs'
+const getDiffBranch = ({
+  packageName,
+  toVersion,
+  useYarnPlugin,
+}: {
+  packageName: string
+  toVersion: string
+  useYarnPlugin: boolean
+}) =>
+  packageName === PACKAGE_NAMES.BACKSTAGE
+    ? `release-diff/${useYarnPlugin ? '' : 'legacy/'}v${toVersion}`
+    : 'diffs'
 
 export const getReleasesFileURL = ({
   packageName,
@@ -48,9 +58,11 @@ export const getDiffURL = ({
 }) => {
   return `https://raw.githubusercontent.com/${getRNDiffRepository({
     packageName,
-  })}/${getDiffBranch({ packageName })}/${
-    useYarnPlugin ? 'diffs-yarn-plugin' : 'diffs'
-  }/${fromVersion}..${toVersion}.diff`
+  })}/${getDiffBranch({
+    packageName,
+    toVersion,
+    useYarnPlugin,
+  })}/diffs/${fromVersion}..${toVersion}.diff`
 }
 
 const getBranch = ({


### PR DESCRIPTION
# Summary

As the size of the diffs has grown consistently, we've now split the diffs into multiple branches. This PR changes how we fetch the diff from the `upgrade-helper-diff` repository.

